### PR TITLE
Implement fuel capacity limit on hauling

### DIFF
--- a/locale/en/transport_drones.cfg
+++ b/locale/en/transport_drones.cfg
@@ -50,6 +50,7 @@ transport-drone-speed=Transport drone speed: +20%
 transport-depot-update-interval=Transport depot update interval
 fuel-fluid=Transport drone fuel
 fuel-amount-per-drone=Transport drone fuel per drone
+drone-fuel-capacity=Transport drone fuel capacity
 drone-fluid-capacity=Transport drone fluid capacity
 fuel-consumption-per-meter=Fuel consumption per meter
 drone-pollution-per-second=Pollution per second

--- a/locale/ru/transport_drones.cfg
+++ b/locale/ru/transport_drones.cfg
@@ -51,6 +51,7 @@ transport-drone-speed=Скорость транспортных беспилот
 transport-depot-update-interval=Интервал обновления транспортных складов
 fuel-fluid=Топливо для транспортного беспилотника
 fuel-amount-per-drone=Топливо для одного транспортного беспилотника
+drone-fuel-capacity=Ёмкость топлива для транспортного беспилотника
 drone-fluid-capacity=Ёмкость жидкости для транспортного беспилотника
 fuel-consumption-per-meter=Расход топлива на метр
 drone-pollution-per-second=Загрязнение в секунду

--- a/locale/zh-CN/transport_drones.cfg
+++ b/locale/zh-CN/transport_drones.cfg
@@ -52,6 +52,7 @@ transport-drone-speed=运输无人车速度：+20%
 transport-depot-update-interval=运输仓库更新
 fuel-fluid=运输无人车燃料
 fuel-amount-per-drone=每架运输无人车燃料
+drone-fuel-capacity=运输无人车燃料容量
 drone-fluid-capacity=运输无人车流体容量
 fuel-consumption-per-meter=每米燃料消耗
 drone-pollution-per-second=每秒污染

--- a/script/depots/buffer_depot.lua
+++ b/script/depots/buffer_depot.lua
@@ -1,5 +1,7 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 
 local request_spawn_timeout = 60
 
@@ -297,7 +299,11 @@ function buffer_depot:make_request()
     if amount < minimum_size then
       return big
     end
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+      return big
+    end
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer

--- a/script/depots/fuel_depot.lua
+++ b/script/depots/fuel_depot.lua
@@ -1,5 +1,7 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 local request_spawn_timeout = 60
 
 local fuel_depot = {}
@@ -29,6 +31,12 @@ local get_corpse_position = function(entity)
   local offset = fuel_depot.corpse_offsets[direction]
   return {position.x + offset[1], position.y + offset[2]}
 
+end
+
+local distance = function(a, b)
+  local dx = a[1] - b[1]
+  local dy = a[2] - b[2]
+  return ((dx * dx) + (dy * dy)) ^ 0.5
 end
 
 function fuel_depot.new(entity, tags)
@@ -166,6 +174,11 @@ function fuel_depot:handle_fuel_request(depot)
     if behavior and behavior.disabled then
       return
     end
+  end
+
+  local dist = distance(self.node_position, depot.node_position)
+  if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+    return
   end
 
   local amount = self:get_fuel_amount()

--- a/script/depots/request_depot.lua
+++ b/script/depots/request_depot.lua
@@ -1,5 +1,7 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 
 local request_depot = {}
 request_depot.metatable = {__index = request_depot}
@@ -233,8 +235,12 @@ function request_depot:make_request()
 
   local node_position = self.node_position
   local heuristic = function(depot, count)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+      return big
+    end
     local amount = min(count, request_size)
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer

--- a/settings.lua
+++ b/settings.lua
@@ -30,6 +30,16 @@ local settings =
 
   {
     type = "double-setting",
+    name = "drone-fuel-capacity",
+    localised_name = "Transport drone fuel capacity",
+    setting_type = "startup",
+    default_value = 50,
+    minimum_value = 1,
+    maximum_value = 10000
+  },
+
+  {
+    type = "double-setting",
     name = "drone-fluid-capacity",
     localised_name = "Transport drone fluid capacity",
     setting_type = "startup",

--- a/shared.lua
+++ b/shared.lua
@@ -12,6 +12,7 @@ data.transport_capacity_technology = "transport-drone-capacity"
 data.transport_system_technology = "transport-system"
 
 data.fuel_amount_per_drone = settings.startup["fuel-amount-per-drone"].value
+data.drone_fuel_capacity = settings.startup["drone-fuel-capacity"].value
 data.fuel_consumption_per_meter = settings.startup["fuel-consumption-per-meter"].value
 data.drone_fluid_capacity = settings.startup["drone-fluid-capacity"].value
 data.drone_pollution_per_second = {pollution = settings.startup["drone-pollution-per-second"].value}


### PR DESCRIPTION
## Summary
- add new `drone-fuel-capacity` startup setting
- expose new setting in localisation files
- read the setting in `shared.lua`
- reject hauling requests if the round trip distance exceeds a drone's fuel capacity

## Testing
- `git status --short`
- *No automated tests available*
