### PR TITLE
Add truck config options

### DIFF
--- a/locale/en/transport_drones.cfg
+++ b/locale/en/transport_drones.cfg
@@ -50,9 +50,13 @@ transport-drone-speed=Transport drone speed: +20%
 transport-depot-update-interval=Transport depot update interval
 fuel-fluid=Transport drone fuel
 fuel-amount-per-drone=Transport drone fuel per drone
+drone-fuel-capacity=Transport drone fuel capacity
 drone-fluid-capacity=Transport drone fluid capacity
 fuel-consumption-per-meter=Fuel consumption per meter
 drone-pollution-per-second=Pollution per second
+transport-drone-base-speed=Transport drone base speed
+truck-departure-delay=Truck departure delay
+max-truck-size=Maximum truck load size
 
 [string-mod-setting]
 fuel-fluid-petroleum-gas=Petroleum gas

--- a/locale/ru/transport_drones.cfg
+++ b/locale/ru/transport_drones.cfg
@@ -51,9 +51,13 @@ transport-drone-speed=Скорость транспортных беспилот
 transport-depot-update-interval=Интервал обновления транспортных складов
 fuel-fluid=Топливо для транспортного беспилотника
 fuel-amount-per-drone=Топливо для одного транспортного беспилотника
+drone-fuel-capacity=Ёмкость топлива для транспортного беспилотника
 drone-fluid-capacity=Ёмкость жидкости для транспортного беспилотника
 fuel-consumption-per-meter=Расход топлива на метр
 drone-pollution-per-second=Загрязнение в секунду
+transport-drone-base-speed=Базовая скорость транспортного беспилотника
+truck-departure-delay=Задержка отправки грузовика
+max-truck-size=Максимальный размер груза грузовика
 
 [string-mod-setting]
 fuel-fluid-petroleum-gas=Попутный нефтяной газ

--- a/locale/zh-CN/transport_drones.cfg
+++ b/locale/zh-CN/transport_drones.cfg
@@ -52,9 +52,13 @@ transport-drone-speed=运输无人车速度：+20%
 transport-depot-update-interval=运输仓库更新
 fuel-fluid=运输无人车燃料
 fuel-amount-per-drone=每架运输无人车燃料
+drone-fuel-capacity=运输无人车燃料容量
 drone-fluid-capacity=运输无人车流体容量
 fuel-consumption-per-meter=每米燃料消耗
 drone-pollution-per-second=每秒污染
+transport-drone-base-speed=运输无人机基础速度
+truck-departure-delay=卡车出发延迟
+max-truck-size=卡车最大装载量
 
 [string-mod-setting]
 fuel-fluid-petroleum-gas=石油气

--- a/script/depots/buffer_depot.lua
+++ b/script/depots/buffer_depot.lua
@@ -1,7 +1,10 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 
-local request_spawn_timeout = 60
+local departure_delay = shared.truck_departure_delay
+local max_truck_size = shared.max_truck_size
 
 local buffer_depot = {}
 buffer_depot.metatable = {__index = buffer_depot}
@@ -261,6 +264,7 @@ function buffer_depot:dispatch_drone(depot, count)
   self.drones[drone.index] = drone
 
   self:update_sticker()
+  self.next_spawn_tick = game.tick + departure_delay
 end
 
 
@@ -280,6 +284,8 @@ function buffer_depot:make_request()
   if not name then return end
   if not quality then return end
 
+  if game.tick < self.next_spawn_tick then return end
+
   if not self:can_spawn_drone() then return end
   if not self:should_order() then return end
 
@@ -297,7 +303,11 @@ function buffer_depot:make_request()
     if amount < minimum_size then
       return big
     end
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+      return big
+    end
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer
@@ -421,7 +431,11 @@ function buffer_depot:get_stack_size()
 end
 
 function buffer_depot:get_request_size()
-  return self:get_stack_size() * (1 + buffer_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local size = self:get_stack_size() * (1 + buffer_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  if max_truck_size > 0 and size > max_truck_size then
+    return max_truck_size
+  end
+  return size
 end
 
 function buffer_depot:get_output_inventory()

--- a/script/depots/fuel_depot.lua
+++ b/script/depots/fuel_depot.lua
@@ -1,6 +1,8 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
-local request_spawn_timeout = 60
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
+local departure_delay = shared.truck_departure_delay
 
 local fuel_depot = {}
 fuel_depot.metatable = {__index = fuel_depot}
@@ -29,6 +31,12 @@ local get_corpse_position = function(entity)
   local offset = fuel_depot.corpse_offsets[direction]
   return {position.x + offset[1], position.y + offset[2]}
 
+end
+
+local distance = function(a, b)
+  local dx = a[1] - b[1]
+  local dy = a[2] - b[2]
+  return ((dx * dx) + (dy * dy)) ^ 0.5
 end
 
 function fuel_depot.new(entity, tags)
@@ -160,12 +168,18 @@ end
 
 function fuel_depot:handle_fuel_request(depot)
   if not self:can_spawn_drone() then return end
+  if game.tick < self.next_spawn_tick then return end
 
   if (self.circuit_writer and self.circuit_writer.valid) then
     local behavior = self.circuit_writer.get_control_behavior()
     if behavior and behavior.disabled then
       return
     end
+  end
+
+  local dist = distance(self.node_position, depot.node_position)
+  if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+    return
   end
 
   local amount = self:get_fuel_amount()
@@ -183,7 +197,7 @@ function fuel_depot:handle_fuel_request(depot)
 
   self.drones[drone.index] = drone
 
-  self.next_spawn_tick = game.tick + request_spawn_timeout
+  self.next_spawn_tick = game.tick + departure_delay
   self:update_sticker()
 
 end

--- a/script/depots/request_depot.lua
+++ b/script/depots/request_depot.lua
@@ -1,5 +1,9 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
+local departure_delay = shared.truck_departure_delay
+local max_truck_size = shared.max_truck_size
 
 local request_depot = {}
 request_depot.metatable = {__index = request_depot}
@@ -50,7 +54,8 @@ function request_depot.new(entity, tags)
     item = false,
     drones = {},
     mode = request_mode.item,
-    fuel_on_the_way = 0
+    fuel_on_the_way = 0,
+    next_spawn_tick = 0
   }
   setmetatable(depot, request_depot.metatable)
 
@@ -216,6 +221,8 @@ function request_depot:make_request()
   local quality = self.type == "fluid" and "" or self.quality
   if not name then return end
   if not quality then return end
+
+  if game.tick < self.next_spawn_tick then return end
   
   if not self:can_spawn_drone() then return end
   if not self:should_order() then return end
@@ -233,8 +240,12 @@ function request_depot:make_request()
 
   local node_position = self.node_position
   local heuristic = function(depot, count)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+      return big
+    end
     local amount = min(count, request_size)
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer
@@ -399,7 +410,11 @@ function request_depot:get_stack_size()
 end
 
 function request_depot:get_request_size()
-  return self:get_stack_size() * (1 + request_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local size = self:get_stack_size() * (1 + request_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  if max_truck_size > 0 and size > max_truck_size then
+    return max_truck_size
+  end
+  return size
 end
 
 function request_depot:get_output_inventory()
@@ -559,6 +574,7 @@ function request_depot:dispatch_drone(depot, count)
   self.drones[drone.index] = drone
 
   self:update_sticker()
+  self.next_spawn_tick = game.tick + departure_delay
 end
 
 local valid_item_cache = {}

--- a/script/transport_drone.lua
+++ b/script/transport_drone.lua
@@ -60,8 +60,9 @@ local states =
   delivering_fuel = 4
 }
 
+local base_speed = shared.drone_base_speed or 0.066
 local get_drone_speed = function(force_index)
-  return (0.066 * (1 + transport_technologies.get_transport_speed_bonus(force_index))) --+ (math.random() / 32)
+  return (base_speed * (1 + transport_technologies.get_transport_speed_bonus(force_index))) --+ (math.random() / 32)
 end
 
 local variation_count = shared.variation_count

--- a/settings.lua
+++ b/settings.lua
@@ -30,6 +30,16 @@ local settings =
 
   {
     type = "double-setting",
+    name = "drone-fuel-capacity",
+    localised_name = "Transport drone fuel capacity",
+    setting_type = "startup",
+    default_value = 50,
+    minimum_value = 1,
+    maximum_value = 10000
+  },
+
+  {
+    type = "double-setting",
     name = "drone-fluid-capacity",
     localised_name = "Transport drone fluid capacity",
     setting_type = "startup",
@@ -54,6 +64,33 @@ local settings =
     setting_type = "startup",
     default_value = 0.005,
     minimum_value = 0
+  },
+  {
+    type = "double-setting",
+    name = "transport-drone-base-speed",
+    localised_name = "Transport drone base speed",
+    setting_type = "startup",
+    default_value = 0.066,
+    minimum_value = 0.01,
+    maximum_value = 1
+  },
+  {
+    type = "int-setting",
+    name = "truck-departure-delay",
+    localised_name = "Truck departure delay",
+    setting_type = "startup",
+    default_value = 60,
+    minimum_value = 0,
+    maximum_value = 3600
+  },
+  {
+    type = "int-setting",
+    name = "max-truck-size",
+    localised_name = "Maximum truck load size",
+    setting_type = "startup",
+    default_value = 0,
+    minimum_value = 0,
+    maximum_value = 10000
   }
 }
 

--- a/shared.lua
+++ b/shared.lua
@@ -12,8 +12,12 @@ data.transport_capacity_technology = "transport-drone-capacity"
 data.transport_system_technology = "transport-system"
 
 data.fuel_amount_per_drone = settings.startup["fuel-amount-per-drone"].value
+data.drone_fuel_capacity = settings.startup["drone-fuel-capacity"].value
 data.fuel_consumption_per_meter = settings.startup["fuel-consumption-per-meter"].value
 data.drone_fluid_capacity = settings.startup["drone-fluid-capacity"].value
 data.drone_pollution_per_second = {pollution = settings.startup["drone-pollution-per-second"].value}
+data.drone_base_speed = settings.startup["transport-drone-base-speed"].value
+data.truck_departure_delay = settings.startup["truck-departure-delay"].value
+data.max_truck_size = settings.startup["max-truck-size"].value
 
 return data


### PR DESCRIPTION
## Summary
- add startup settings for drone base speed, truck departure delay, and max truck size
- expose new settings via `shared.lua`
- respect departure delay and max truck size in request, buffer, and fuel depots
- compute drone speed from base speed setting
- localise new settings for EN/RU/zh-CN

## Testing
- `luac -p settings.lua && echo OK`