### PR TITLE
Make new truck options runtime settings

### DIFF
--- a/locale/en/transport_drones.cfg
+++ b/locale/en/transport_drones.cfg
@@ -48,8 +48,12 @@ transport-drone-capacity=Transport drone stack capacity: +1
 transport-drone-speed=Transport drone speed: +20%
 [mod-setting-name]
 transport-depot-update-interval=Transport depot update interval
+base-truck-speed=Base truck speed
+truck-departure-delay=Truck dispatch delay (ticks)
+max-truck-load-size=Maximum truck load size
 fuel-fluid=Transport drone fuel
 fuel-amount-per-drone=Transport drone fuel per drone
+drone-fuel-capacity=Transport drone fuel capacity
 drone-fluid-capacity=Transport drone fluid capacity
 fuel-consumption-per-meter=Fuel consumption per meter
 drone-pollution-per-second=Pollution per second

--- a/locale/ru/transport_drones.cfg
+++ b/locale/ru/transport_drones.cfg
@@ -49,8 +49,12 @@ transport-drone-speed=Скорость транспортных беспилот
 
 [mod-setting-name]
 transport-depot-update-interval=Интервал обновления транспортных складов
+base-truck-speed=Базовая скорость грузовика
+truck-departure-delay=Задержка отправки грузовиков
+max-truck-load-size=Максимальный размер груза грузовика
 fuel-fluid=Топливо для транспортного беспилотника
 fuel-amount-per-drone=Топливо для одного транспортного беспилотника
+drone-fuel-capacity=Ёмкость топлива для транспортного беспилотника
 drone-fluid-capacity=Ёмкость жидкости для транспортного беспилотника
 fuel-consumption-per-meter=Расход топлива на метр
 drone-pollution-per-second=Загрязнение в секунду

--- a/locale/zh-CN/transport_drones.cfg
+++ b/locale/zh-CN/transport_drones.cfg
@@ -50,8 +50,12 @@ transport-drone-speed=运输无人车速度：+20%
 
 [mod-setting-name]
 transport-depot-update-interval=运输仓库更新
+base-truck-speed=基础运输车速度
+truck-departure-delay=运输车出发延迟
+max-truck-load-size=运输车最大装载量
 fuel-fluid=运输无人车燃料
 fuel-amount-per-drone=每架运输无人车燃料
+drone-fuel-capacity=运输无人车燃料容量
 drone-fluid-capacity=运输无人车流体容量
 fuel-consumption-per-meter=每米燃料消耗
 drone-pollution-per-second=每秒污染

--- a/script/depots/buffer_depot.lua
+++ b/script/depots/buffer_depot.lua
@@ -1,7 +1,11 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local get_drone_fuel_capacity = shared.get_drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 
-local request_spawn_timeout = 60
+local function dispatch_delay()
+  return settings.global["truck-departure-delay"].value
+end
 
 local buffer_depot = {}
 buffer_depot.metatable = {__index = buffer_depot}
@@ -254,12 +258,14 @@ end
 
 local min = math.min
 function buffer_depot:dispatch_drone(depot, count)
+  if game.tick < self.next_spawn_tick then return end
   local drone = self.transport_drone.new(self, self.item)
   drone:pickup_from_supply(depot, self.item,self.quality, count)
   self:remove_fuel(fuel_amount_per_drone)
 
   self.drones[drone.index] = drone
 
+  self.next_spawn_tick = game.tick + dispatch_delay()
   self:update_sticker()
 end
 
@@ -297,7 +303,11 @@ function buffer_depot:make_request()
     if amount < minimum_size then
       return big
     end
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > get_drone_fuel_capacity() then
+      return big
+    end
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer
@@ -421,7 +431,12 @@ function buffer_depot:get_stack_size()
 end
 
 function buffer_depot:get_request_size()
-  return self:get_stack_size() * (1 + buffer_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local size = self:get_stack_size() * (1 + buffer_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local max_load = settings.global["max-truck-load-size"].value
+  if size > max_load then
+    return max_load
+  end
+  return size
 end
 
 function buffer_depot:get_output_inventory()

--- a/script/depots/fuel_depot.lua
+++ b/script/depots/fuel_depot.lua
@@ -1,6 +1,11 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
-local request_spawn_timeout = 60
+local get_drone_fuel_capacity = shared.get_drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
+
+local function dispatch_delay()
+  return settings.global["truck-departure-delay"].value
+end
 
 local fuel_depot = {}
 fuel_depot.metatable = {__index = fuel_depot}
@@ -29,6 +34,12 @@ local get_corpse_position = function(entity)
   local offset = fuel_depot.corpse_offsets[direction]
   return {position.x + offset[1], position.y + offset[2]}
 
+end
+
+local distance = function(a, b)
+  local dx = a[1] - b[1]
+  local dy = a[2] - b[2]
+  return ((dx * dx) + (dy * dy)) ^ 0.5
 end
 
 function fuel_depot.new(entity, tags)
@@ -160,12 +171,18 @@ end
 
 function fuel_depot:handle_fuel_request(depot)
   if not self:can_spawn_drone() then return end
+  if game.tick < self.next_spawn_tick then return end
 
   if (self.circuit_writer and self.circuit_writer.valid) then
     local behavior = self.circuit_writer.get_control_behavior()
     if behavior and behavior.disabled then
       return
     end
+  end
+
+  local dist = distance(self.node_position, depot.node_position)
+  if (dist * 2 * fuel_consumption_per_meter) > get_drone_fuel_capacity() then
+    return
   end
 
   local amount = self:get_fuel_amount()
@@ -183,7 +200,7 @@ function fuel_depot:handle_fuel_request(depot)
 
   self.drones[drone.index] = drone
 
-  self.next_spawn_tick = game.tick + request_spawn_timeout
+  self.next_spawn_tick = game.tick + dispatch_delay()
   self:update_sticker()
 
 end

--- a/script/depots/request_depot.lua
+++ b/script/depots/request_depot.lua
@@ -1,5 +1,11 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local get_drone_fuel_capacity = shared.get_drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
+
+local function dispatch_delay()
+  return settings.global["truck-departure-delay"].value
+end
 
 local request_depot = {}
 request_depot.metatable = {__index = request_depot}
@@ -49,6 +55,7 @@ function request_depot.new(entity, tags)
     index = tostring(entity.unit_number),
     item = false,
     drones = {},
+    next_spawn_tick = 0,
     mode = request_mode.item,
     fuel_on_the_way = 0
   }
@@ -233,8 +240,12 @@ function request_depot:make_request()
 
   local node_position = self.node_position
   local heuristic = function(depot, count)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > get_drone_fuel_capacity() then
+      return big
+    end
     local amount = min(count, request_size)
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer
@@ -399,7 +410,12 @@ function request_depot:get_stack_size()
 end
 
 function request_depot:get_request_size()
-  return self:get_stack_size() * (1 + request_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local size = self:get_stack_size() * (1 + request_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local max_load = settings.global["max-truck-load-size"].value
+  if size > max_load then
+    return max_load
+  end
+  return size
 end
 
 function request_depot:get_output_inventory()
@@ -551,13 +567,14 @@ end
 
 local min = math.min
 function request_depot:dispatch_drone(depot, count)
-
+  if game.tick < self.next_spawn_tick then return end
   local drone = self.transport_drone.new(self, self.item)
   drone:pickup_from_supply(depot, self.item,self.quality, count)
   self:remove_fuel(fuel_amount_per_drone)
 
   self.drones[drone.index] = drone
 
+  self.next_spawn_tick = game.tick + dispatch_delay()
   self:update_sticker()
 end
 

--- a/script/transport_drone.lua
+++ b/script/transport_drone.lua
@@ -60,8 +60,12 @@ local states =
   delivering_fuel = 4
 }
 
+local function base_speed()
+  return settings.global["base-truck-speed"].value
+end
+
 local get_drone_speed = function(force_index)
-  return (0.066 * (1 + transport_technologies.get_transport_speed_bonus(force_index))) --+ (math.random() / 32)
+  return (base_speed() * (1 + transport_technologies.get_transport_speed_bonus(force_index))) --+ (math.random() / 32)
 end
 
 local variation_count = shared.variation_count

--- a/settings.lua
+++ b/settings.lua
@@ -11,6 +11,36 @@ local settings =
   },
 
   {
+    type = "double-setting",
+    name = "base-truck-speed",
+    localised_name = "Base truck speed",
+    setting_type = "runtime-global",
+    default_value = 0.066,
+    minimum_value = 0.01,
+    maximum_value = 1
+  },
+
+  {
+    type = "int-setting",
+    name = "truck-departure-delay",
+    localised_name = "Truck dispatch delay (ticks)",
+    setting_type = "runtime-global",
+    default_value = 60,
+    minimum_value = 0,
+    maximum_value = 3600
+  },
+
+  {
+    type = "int-setting",
+    name = "max-truck-load-size",
+    localised_name = "Maximum truck load size",
+    setting_type = "runtime-global",
+    default_value = 100,
+    minimum_value = 1,
+    maximum_value = 5000
+  },
+
+  {
     type = "string-setting",
     name = "fuel-fluid",
     localised_name = "Transport drone fuel",
@@ -25,6 +55,16 @@ local settings =
     setting_type = "startup",
     default_value = 50,
     minimum_value = 0,
+    maximum_value = 10000
+  },
+
+  {
+    type = "double-setting",
+    name = "drone-fuel-capacity",
+    localised_name = "Transport drone fuel capacity",
+    setting_type = "runtime-global",
+    default_value = 50,
+    minimum_value = 1,
     maximum_value = 10000
   },
 

--- a/shared.lua
+++ b/shared.lua
@@ -12,6 +12,12 @@ data.transport_capacity_technology = "transport-drone-capacity"
 data.transport_system_technology = "transport-system"
 
 data.fuel_amount_per_drone = settings.startup["fuel-amount-per-drone"].value
+data.get_drone_fuel_capacity = function()
+  if settings and settings.global then
+    return settings.global["drone-fuel-capacity"].value
+  end
+  return settings.startup["drone-fuel-capacity"].value
+end
 data.fuel_consumption_per_meter = settings.startup["fuel-consumption-per-meter"].value
 data.drone_fluid_capacity = settings.startup["drone-fluid-capacity"].value
 data.drone_pollution_per_second = {pollution = settings.startup["drone-pollution-per-second"].value}


### PR DESCRIPTION
## Summary
- add base truck speed, dispatch delay, and max load size as runtime settings
- change drone fuel capacity to be runtime configurable
- clamp request sizes and gate dispatch with new settings
- use new base speed for trucks

## Testing
- `luac -p settings.lua && echo OK`