### PR TITLE
Add runtime truck settings and use util.distance

### DIFF
--- a/locale/en/transport_drones.cfg
+++ b/locale/en/transport_drones.cfg
@@ -50,9 +50,13 @@ transport-drone-speed=Transport drone speed: +20%
 transport-depot-update-interval=Transport depot update interval
 fuel-fluid=Transport drone fuel
 fuel-amount-per-drone=Transport drone fuel per drone
+drone-fuel-capacity=Transport drone fuel capacity
 drone-fluid-capacity=Transport drone fluid capacity
 fuel-consumption-per-meter=Fuel consumption per meter
 drone-pollution-per-second=Pollution per second
+base-truck-speed=Base truck speed
+truck-departure-delay=Truck departure delay
+max-truck-load-size=Max truck load size
 
 [string-mod-setting]
 fuel-fluid-petroleum-gas=Petroleum gas

--- a/locale/ru/transport_drones.cfg
+++ b/locale/ru/transport_drones.cfg
@@ -51,9 +51,13 @@ transport-drone-speed=Скорость транспортных беспилот
 transport-depot-update-interval=Интервал обновления транспортных складов
 fuel-fluid=Топливо для транспортного беспилотника
 fuel-amount-per-drone=Топливо для одного транспортного беспилотника
+drone-fuel-capacity=Ёмкость топлива для транспортного беспилотника
 drone-fluid-capacity=Ёмкость жидкости для транспортного беспилотника
 fuel-consumption-per-meter=Расход топлива на метр
 drone-pollution-per-second=Загрязнение в секунду
+base-truck-speed=Базовая скорость грузовика
+truck-departure-delay=Задержка отправки грузовика
+max-truck-load-size=Максимальный размер груза грузовика
 
 [string-mod-setting]
 fuel-fluid-petroleum-gas=Попутный нефтяной газ

--- a/locale/zh-CN/transport_drones.cfg
+++ b/locale/zh-CN/transport_drones.cfg
@@ -52,9 +52,13 @@ transport-drone-speed=运输无人车速度：+20%
 transport-depot-update-interval=运输仓库更新
 fuel-fluid=运输无人车燃料
 fuel-amount-per-drone=每架运输无人车燃料
+drone-fuel-capacity=运输无人车燃料容量
 drone-fluid-capacity=运输无人车流体容量
 fuel-consumption-per-meter=每米燃料消耗
 drone-pollution-per-second=每秒污染
+base-truck-speed=运输车基础速度
+truck-departure-delay=运输车出发延迟
+max-truck-load-size=运输车最大载量
 
 [string-mod-setting]
 fuel-fluid-petroleum-gas=石油气

--- a/script/depots/buffer_depot.lua
+++ b/script/depots/buffer_depot.lua
@@ -1,7 +1,8 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 
-local request_spawn_timeout = 60
 
 local buffer_depot = {}
 buffer_depot.metatable = {__index = buffer_depot}
@@ -261,14 +262,11 @@ function buffer_depot:dispatch_drone(depot, count)
   self.drones[drone.index] = drone
 
   self:update_sticker()
+  self.next_spawn_tick = game.tick + settings.global["truck-departure-delay"].value
 end
 
 
-local distance = function(a, b)
-  local dx = a[1] - b[1]
-  local dy = a[2] - b[2]
-  return ((dx * dx) + (dy * dy)) ^ 0.5
-end
+local distance = util.distance
 
 local big = math.huge
 local min = math.min
@@ -279,6 +277,8 @@ function buffer_depot:make_request()
   local quality = self.type == "fluid" and "" or self.quality
   if not name then return end
   if not quality then return end
+
+  if game.tick < self.next_spawn_tick then return end
 
   if not self:can_spawn_drone() then return end
   if not self:should_order() then return end
@@ -297,7 +297,11 @@ function buffer_depot:make_request()
     if amount < minimum_size then
       return big
     end
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+      return big
+    end
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer
@@ -421,7 +425,9 @@ function buffer_depot:get_stack_size()
 end
 
 function buffer_depot:get_request_size()
-  return self:get_stack_size() * (1 + buffer_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local base = self:get_stack_size() * (1 + buffer_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local max_size = settings.global["max-truck-load-size"].value
+  return math.min(base, max_size)
 end
 
 function buffer_depot:get_output_inventory()

--- a/script/depots/fuel_depot.lua
+++ b/script/depots/fuel_depot.lua
@@ -1,6 +1,7 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
-local request_spawn_timeout = 60
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 
 local fuel_depot = {}
 fuel_depot.metatable = {__index = fuel_depot}
@@ -30,6 +31,8 @@ local get_corpse_position = function(entity)
   return {position.x + offset[1], position.y + offset[2]}
 
 end
+
+local distance = util.distance
 
 function fuel_depot.new(entity, tags)
 
@@ -159,6 +162,7 @@ function fuel_depot:get_drone_fluid_capacity()
 end
 
 function fuel_depot:handle_fuel_request(depot)
+  if game.tick < self.next_spawn_tick then return end
   if not self:can_spawn_drone() then return end
 
   if (self.circuit_writer and self.circuit_writer.valid) then
@@ -166,6 +170,11 @@ function fuel_depot:handle_fuel_request(depot)
     if behavior and behavior.disabled then
       return
     end
+  end
+
+  local dist = distance(self.node_position, depot.node_position)
+  if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+    return
   end
 
   local amount = self:get_fuel_amount()
@@ -183,7 +192,7 @@ function fuel_depot:handle_fuel_request(depot)
 
   self.drones[drone.index] = drone
 
-  self.next_spawn_tick = game.tick + request_spawn_timeout
+  self.next_spawn_tick = game.tick + settings.global["truck-departure-delay"].value
   self:update_sticker()
 
 end

--- a/script/depots/request_depot.lua
+++ b/script/depots/request_depot.lua
@@ -1,5 +1,7 @@
 local fuel_amount_per_drone = shared.fuel_amount_per_drone
 local drone_fluid_capacity = shared.drone_fluid_capacity
+local drone_fuel_capacity = shared.drone_fuel_capacity
+local fuel_consumption_per_meter = shared.fuel_consumption_per_meter
 
 local request_depot = {}
 request_depot.metatable = {__index = request_depot}
@@ -202,11 +204,7 @@ function request_depot:get_minimum_request_size()
 end
 
 
-local distance = function(a, b)
-  local dx = a[1] - b[1]
-  local dy = a[2] - b[2]
-  return ((dx * dx) + (dy * dy)) ^ 0.5
-end
+local distance = util.distance
 
 local big = math.huge
 local min = math.min
@@ -233,8 +231,12 @@ function request_depot:make_request()
 
   local node_position = self.node_position
   local heuristic = function(depot, count)
+    local dist = distance(depot.node_position, node_position)
+    if (dist * 2 * fuel_consumption_per_meter) > drone_fuel_capacity then
+      return big
+    end
     local amount = min(count, request_size)
-    return distance(depot.node_position, node_position) - ((amount / request_size) * item_heuristic_bonus)
+    return dist - ((amount / request_size) * item_heuristic_bonus)
   end
 
   local best_buffer
@@ -399,7 +401,9 @@ function request_depot:get_stack_size()
 end
 
 function request_depot:get_request_size()
-  return self:get_stack_size() * (1 + request_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local base = self:get_stack_size() * (1 + request_depot.transport_technologies.get_transport_capacity_bonus(self.entity.force.index))
+  local max_size = settings.global["max-truck-load-size"].value
+  return math.min(base, max_size)
 end
 
 function request_depot:get_output_inventory()

--- a/script/script_util.lua
+++ b/script/script_util.lua
@@ -42,9 +42,6 @@ util.center = function(area)
   return {x = (area.left_top.x + area.right_bottom.x) / 2, y = (area.left_top.y + area.right_bottom.y) / 2}
 end
 
-util.distance = function(p1, p2)
-  return (((p1.x - p2.x) ^ 2) + ((p1.y - p2.y) ^ 2)) ^ 0.5
-end
 
 util.radius = function(area)
   return util.distance(area.right_bottom, area.left_top) / 2

--- a/script/transport_drone.lua
+++ b/script/transport_drone.lua
@@ -61,7 +61,8 @@ local states =
 }
 
 local get_drone_speed = function(force_index)
-  return (0.066 * (1 + transport_technologies.get_transport_speed_bonus(force_index))) --+ (math.random() / 32)
+  local base = settings.global["base-truck-speed"].value
+  return (base * (1 + transport_technologies.get_transport_speed_bonus(force_index)))
 end
 
 local variation_count = shared.variation_count

--- a/settings.lua
+++ b/settings.lua
@@ -30,6 +30,16 @@ local settings =
 
   {
     type = "double-setting",
+    name = "drone-fuel-capacity",
+    localised_name = "Transport drone fuel capacity",
+    setting_type = "startup",
+    default_value = 50,
+    minimum_value = 1,
+    maximum_value = 10000
+  },
+
+  {
+    type = "double-setting",
     name = "drone-fluid-capacity",
     localised_name = "Transport drone fluid capacity",
     setting_type = "startup",
@@ -54,6 +64,36 @@ local settings =
     setting_type = "startup",
     default_value = 0.005,
     minimum_value = 0
+  },
+
+  {
+    type = "double-setting",
+    name = "base-truck-speed",
+    localised_name = "Base truck speed",
+    setting_type = "runtime-global",
+    default_value = 0.066,
+    minimum_value = 0.01,
+    maximum_value = 1
+  },
+
+  {
+    type = "int-setting",
+    name = "truck-departure-delay",
+    localised_name = "Truck departure delay",
+    setting_type = "runtime-global",
+    default_value = 60,
+    minimum_value = 0,
+    maximum_value = 3600
+  },
+
+  {
+    type = "int-setting",
+    name = "max-truck-load-size",
+    localised_name = "Max truck load size",
+    setting_type = "runtime-global",
+    default_value = 200,
+    minimum_value = 1,
+    maximum_value = 10000
   }
 }
 

--- a/shared.lua
+++ b/shared.lua
@@ -12,6 +12,7 @@ data.transport_capacity_technology = "transport-drone-capacity"
 data.transport_system_technology = "transport-system"
 
 data.fuel_amount_per_drone = settings.startup["fuel-amount-per-drone"].value
+data.drone_fuel_capacity = settings.startup["drone-fuel-capacity"].value
 data.fuel_consumption_per_meter = settings.startup["fuel-consumption-per-meter"].value
 data.drone_fluid_capacity = settings.startup["drone-fluid-capacity"].value
 data.drone_pollution_per_second = {pollution = settings.startup["drone-pollution-per-second"].value}


### PR DESCRIPTION
## Summary
- configure base truck speed, departure delay, and max load as map settings
- stop redefining `util.distance` and use the built‑in distance helper
- throttle depot dispatches using the configured delay
- cap request sizes with the maximum truck load option
- calculate drone speed from the runtime base speed

## Testing
- `luac -p settings.lua && echo OK`
- `luac -p script/depots/buffer_depot.lua && echo OK`
- `luac -p script/depots/fuel_depot.lua && echo OK`
- `luac -p script/depots/request_depot.lua && echo OK`
- `luac -p script/script_util.lua && echo OK`
- `luac -p script/transport_drone.lua && echo OK`
